### PR TITLE
Feature: mobile local only

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -34,6 +34,7 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
       'setting_default_sensitive' => source_params.fetch(:sensitive, @account.user.setting_default_sensitive),
       'setting_default_language' => source_params.fetch(:language, @account.user.setting_default_language),
       'setting_default_federation' => source_params.fetch(:federation, @account.user.setting_default_federation),
+      'setting_mobile_federation' => source_params.fetch(:mobilefederation, @account.user.setting_default_federation),
     }
   end
 end

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -41,6 +41,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_default_sensitive,
       :setting_default_language,
       :setting_default_federation,
+      :setting_mobile_federation,
       :setting_unfollow_modal,
       :setting_boost_modal,
       :setting_delete_modal,

--- a/app/javascript/mastodon/locales/zh-CN.json
+++ b/app/javascript/mastodon/locales/zh-CN.json
@@ -336,7 +336,7 @@
   "status.favourite": "收藏",
   "status.filtered": "已过滤",
   "status.load_more": "加载更多",
-  "status.local_only": "This post is only visible by other users of your instance",
+  "status.local_only": "此嘟文仅本站用户可见",
   "status.media_hidden": "隐藏媒体内容",
   "status.mention": "提及 @{name}",
   "status.more": "更多",

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -21,6 +21,7 @@ class UserSettingsDecorator
     user.settings['default_sensitive']   = default_sensitive_preference if change?('setting_default_sensitive')
     user.settings['default_language']    = default_language_preference if change?('setting_default_language')
     user.settings['default_federation']  = default_federation_preference if change?('setting_default_federation')
+    user.settings['mobile_federation']  = mobile_federation_preference if change?('setting_mobile_federation')
     user.settings['unfollow_modal']      = unfollow_modal_preference if change?('setting_unfollow_modal')
     user.settings['boost_modal']         = boost_modal_preference if change?('setting_boost_modal')
     user.settings['delete_modal']        = delete_modal_preference if change?('setting_delete_modal')
@@ -60,6 +61,10 @@ class UserSettingsDecorator
     boolean_cast_setting 'setting_default_federation'
   end
 
+  def mobile_federation_preference
+    boolean_cast_setting 'setting_mobile_federation'
+  end
+  
   def unfollow_modal_preference
     boolean_cast_setting 'setting_unfollow_modal'
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,7 +108,7 @@ class User < ApplicationRecord
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_media, :hide_network,
            :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
            :advanced_layout, :use_blurhash, :use_pending_items, :trends,
-           :default_federation, to: :settings, prefix: :setting, allow_nil: false
+           :default_federation, :mobile_federation, to: :settings, prefix: :setting, allow_nil: false
 
   attr_reader :invite_code
   attr_writer :external

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -50,6 +50,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:default_privacy]   = object.current_account.user.setting_default_privacy
       store[:default_sensitive] = object.current_account.user.setting_default_sensitive
       store[:default_federation] = object.current_account.user.setting_default_federation
+      store[:mobile_federation] = object.current_account.user.setting_mobile_federation
     end
 
     store[:text] = object.text if object.text

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -11,6 +11,7 @@ class REST::CredentialAccountSerializer < REST::AccountSerializer
       sensitive: user.setting_default_sensitive,
       language: user.setting_default_language,
       federation: user.setting_default_federation,
+      mobilefederation: user.setting_mobile_federation,
       note: object.note,
       fields: object.fields.map(&:to_h),
     }

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -96,10 +96,14 @@ class PostStatusService < BaseService
 
   end
 
-  def local_only_option(local_only, in_reply_to, federation_setting)
-    return in_reply_to&.local_only? if local_only.nil? # XXX temporary, just until clients implement to avoid leaking local_only posts
-    return federation_setting if local_only.nil?
-    local_only
+  def local_only_option(local_only, in_reply_to, content)
+    if local_only.nil?  # Clients
+      return true if in_reply_to&.local_only?  # Force local only reply from clients. Does not affect web interface.
+      return true if /:local: ?\z/.match?(content) # :local: emoji with zero or one space at the end of the status
+      false
+    else  # Web
+      local_only
+    end
   end
 
   def validate_media!
@@ -170,7 +174,7 @@ class PostStatusService < BaseService
       visibility: @visibility,
       language: language_from_option(@options[:language]) || @account.user&.setting_default_language&.presence || LanguageDetector.instance.detect(@text, @account),
       application: @options[:application],
-      local_only: local_only_option(@options[:local_only], @in_reply_to, @account.user&.setting_default_federation)
+      local_only: local_only_option(@options[:local_only], @in_reply_to, @text)
   }.compact
   end
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -96,9 +96,10 @@ class PostStatusService < BaseService
 
   end
 
-  def local_only_option(local_only, in_reply_to, content)
+  def local_only_option(local_only, in_reply_to, content, mobile_federation_setting)
     if local_only.nil?  # Clients
       return true if in_reply_to&.local_only?  # Force local only reply from clients. Does not affect web interface.
+      return true if mobile_federation_setting # true (force local only)
       return true if /:local: ?\z/.match?(content) # :local: emoji with zero or one space at the end of the status
       false
     else  # Web
@@ -174,7 +175,7 @@ class PostStatusService < BaseService
       visibility: @visibility,
       language: language_from_option(@options[:language]) || @account.user&.setting_default_language&.presence || LanguageDetector.instance.detect(@text, @account),
       application: @options[:application],
-      local_only: local_only_option(@options[:local_only], @in_reply_to, @text)
+      local_only: local_only_option(@options[:local_only], @in_reply_to, @text, @account.user&.setting_mobile_federation)
   }.compact
   end
 

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -26,6 +26,9 @@
     = f.input :setting_default_federation, as: :boolean, wrapper: :with_label
 
   .fields-group
+    = f.input :setting_mobile_federation, as: :boolean, wrapper: :with_label
+
+  .fields-group
     = f.input :setting_default_sensitive, as: :boolean, wrapper: :with_label
 
   .fields-group

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -36,6 +36,7 @@ en:
         setting_show_application: The application you use to toot will be displayed in the detailed view of your toots
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
+        setting_default_federation: "This setting does not affect mobile clients. For mobile client users, please add :local: at the end of your toot to post it as local-only."
         username: Your username will be unique on %{domain}
         whole_word: When the keyword or phrase is alphanumeric only, it will only be applied if it matches the whole word
       domain_allow:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -37,6 +37,7 @@ en:
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
         setting_default_federation: "This setting does not affect mobile clients. For mobile client users, please add :local: at the end of your toot to post it as local-only."
+        setting_mobile_federation: Be aware, if this checkbox is checked, users from other instances will never receive your replies, mentions or direct messages which are sent from mobile apps.
         username: Your username will be unique on %{domain}
         whole_word: When the keyword or phrase is alphanumeric only, it will only be applied if it matches the whole word
       domain_allow:
@@ -101,6 +102,7 @@ en:
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting
         setting_default_federation: Allow my toots to reach other instances by default
+        setting_mobile_federation: Force all toots sent from mobile clients to be local-only (Not recommended)
         setting_default_language: Posting language
         setting_default_privacy: Posting privacy
         setting_default_sensitive: Always mark media as sensitive

--- a/config/locales/simple_form.zh-CN.yml
+++ b/config/locales/simple_form.zh-CN.yml
@@ -36,6 +36,7 @@ zh-CN:
         setting_show_application: 你用来发表嘟文的应用程序将会在你嘟文的详细内容中显示
         setting_use_blurhash: 渐变是基于模糊后的隐藏内容生成的
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
+        setting_default_federation: "此设置仅对网页版有效。手机客户端用户在嘟文末尾添加:local:即可发布仅本站可见的嘟文"
         username: 你的用户名在 %{domain} 上是独特的
         whole_word: 如果关键词只包含字母和数字，就只会在整个词被匹配时才会套用
       featured_tag:

--- a/config/locales/simple_form.zh-CN.yml
+++ b/config/locales/simple_form.zh-CN.yml
@@ -36,7 +36,8 @@ zh-CN:
         setting_show_application: 你用来发表嘟文的应用程序将会在你嘟文的详细内容中显示
         setting_use_blurhash: 渐变是基于模糊后的隐藏内容生成的
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
-        setting_default_federation: "此设置仅对网页版有效。手机客户端用户在嘟文末尾添加:local:即可发布仅本站可见的嘟文"
+        setting_default_federation: "此设置仅对网页版有效。手机客户端在嘟文末尾添加:local:即可发布仅本站可见的嘟文"
+        setting_mobile_federation: 请注意，如果勾选此选项，其他实例（站点）上的用户将无法收到您从手机客户端所发的回复、@和私信。
         username: 你的用户名在 %{domain} 上是独特的
         whole_word: 如果关键词只包含字母和数字，就只会在整个词被匹配时才会套用
       featured_tag:
@@ -97,6 +98,7 @@ zh-CN:
         setting_auto_play_gif: 自动播放 GIF 动画
         setting_boost_modal: 在转嘟前询问我
         setting_default_federation: 默认允许嘟文跨站传播至其它长毛象实例
+        setting_mobile_federation: 强制手机客户端发布的嘟文为仅本站可见（不推荐）
         setting_default_language: 发布语言
         setting_default_privacy: 嘟文默认可见范围
         setting_default_sensitive: 总是将我发送的媒体文件标记为敏感内容

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,7 +17,8 @@ defaults: &defaults
   timeline_preview: true
   show_staff_badge: true
   default_sensitive: false
-  default_federation: true
+  default_federation: true # true: Not local-only
+  mobile_federation: false # true: force local-only
   hide_network: false
   unfollow_modal: false
   boost_modal: false


### PR DESCRIPTION
1) Any toot ends with `:local:` (with or without one trailing space) will be auto converted to local-only if it is sent from mobile clients .
You may want to add an emoji for `:local:`, but I don't know which is better. I'm using a transparent png for site J.
2) Added another setting in Preference => Other. "Force all toots sent from mobile clients to be local-only (Not recommended)"
3) Some hints and translations.

