### PR TITLE
Fix advanced interface column width

### DIFF
--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -26,3 +26,7 @@
 @import 'mastodon/dashboard';
 @import 'mastodon/rtl';
 @import 'mastodon/accessibility';
+
+.column {
+    flex-grow: 1;
+  }


### PR DESCRIPTION
Auto resize column width for advanced web interface.
Applies to the three mastodon default themes only: `mastodon` `high contrast` `mastodon-light`