### PR TITLE
Fix background audio & video

### DIFF
--- a/app/javascript/mastodon/components/scrollable_list.js
+++ b/app/javascript/mastodon/components/scrollable_list.js
@@ -212,13 +212,10 @@ export default class ScrollableList extends PureComponent {
   }
 
   attachIntersectionObserver () {
-    let nodeOptions = {
+    this.intersectionObserverWrapper.connect({
       root: this.node,
       rootMargin: '300% 0px',
-    };
-
-    this.intersectionObserverWrapper
-      .connect(this.props.bindToDocument ? {} : nodeOptions);
+    });
   }
 
   detachIntersectionObserver () {

--- a/app/javascript/mastodon/features/audio/index.js
+++ b/app/javascript/mastodon/features/audio/index.js
@@ -60,8 +60,6 @@ class Audio extends React.PureComponent {
     if (this.waveform) {
       this._updateWaveform();
     }
-
-    window.addEventListener('scroll', this.handleScroll);
   }
 
   componentDidUpdate (prevProps) {
@@ -71,8 +69,6 @@ class Audio extends React.PureComponent {
   }
 
   componentWillUnmount () {
-    window.removeEventListener('scroll', this.handleScroll);
-
     if (this.wavesurfer) {
       this.wavesurfer.destroy();
       this.wavesurfer = null;
@@ -177,19 +173,6 @@ class Audio extends React.PureComponent {
       this.wavesurfer.setVolume(slideamt);
     }
   }, 60);
-
-  handleScroll = throttle(() => {
-    if (!this.waveform || !this.wavesurfer) {
-      return;
-    }
-
-    const { top, height } = this.waveform.getBoundingClientRect();
-    const inView = (top <= (window.innerHeight || document.documentElement.clientHeight)) && (top + height >= 0);
-
-    if (!this.state.paused && !inView) {
-      this.setState({ paused: true }, () => this.wavesurfer.pause());
-    }
-  }, 150, { trailing: true })
 
   render () {
     const { height, intl, alt, editable } = this.props;

--- a/app/javascript/mastodon/features/video/index.js
+++ b/app/javascript/mastodon/features/video/index.js
@@ -277,16 +277,12 @@ class Video extends React.PureComponent {
     document.addEventListener('mozfullscreenchange', this.handleFullscreenChange, true);
     document.addEventListener('MSFullscreenChange', this.handleFullscreenChange, true);
 
-    window.addEventListener('scroll', this.handleScroll);
-
     if (this.props.blurhash) {
       this._decode();
     }
   }
 
   componentWillUnmount () {
-    window.removeEventListener('scroll', this.handleScroll);
-
     document.removeEventListener('fullscreenchange', this.handleFullscreenChange, true);
     document.removeEventListener('webkitfullscreenchange', this.handleFullscreenChange, true);
     document.removeEventListener('mozfullscreenchange', this.handleFullscreenChange, true);
@@ -322,19 +318,6 @@ class Video extends React.PureComponent {
       ctx.putImageData(imageData, 0, 0);
     }
   }
-
-  handleScroll = throttle(() => {
-    if (!this.video) {
-      return;
-    }
-
-    const { top, height } = this.video.getBoundingClientRect();
-    const inView = (top <= (window.innerHeight || document.documentElement.clientHeight)) && (top + height >= 0);
-
-    if (!this.state.paused && !inView) {
-      this.setState({ paused: true }, () => this.video.pause());
-    }
-  }, 150, { trailing: true })
 
   handleFullscreenChange = () => {
     this.setState({ fullscreen: isFullscreen() });


### PR DESCRIPTION
This PR does the following:

- BREAKS the intersection observer fix introduced in https://github.com/tootsuite/mastodon/pull/12735. So that the media does not get unloaded when scrolled out of view.
- Revert https://github.com/tootsuite/mastodon/pull/12486. The mentioned PR stops media playback immediately before it's unloaded sometime when scrolled out of view. Read its thread for more details.

The two changes above do fix the bug. (Although it's considered a feature by Mastodon developers.) I don't see any visible side effects yet.
However, I am not sure if https://github.com/tootsuite/mastodon/pull/12744 is relevant. Don't know if reverting this commit (restore those deleted lines) will help reduce the load or utilize some cache. Can't see any difference on my machine.

