### PR TITLE
[Important] Fix MathJAX

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,7 +22,7 @@ Rails.application.config.content_security_policy do |p|
   p.frame_ancestors :none
   p.font_src        :self, assets_host
   p.img_src         :self, :https, :data, :blob, assets_host
-  p.style_src       :self, assets_host
+  p.style_src       :self, :unsafe_inline, assets_host
   p.media_src       :self, :https, :data, assets_host
   p.frame_src       :self, :https
   p.manifest_src    :self, assets_host


### PR DESCRIPTION
### Changelog

Fix MathJAX.

Before:
![image](https://user-images.githubusercontent.com/53662960/85598362-7f09ae80-b619-11ea-83b4-5ea4123942cc.png)

After:
![image](https://user-images.githubusercontent.com/53662960/85598528-aa8c9900-b619-11ea-9314-6dadccf1917b.png)

### Reasoning

A recent change to upstream removed `unsafe-inline` from `style-src` CSP directive. It breaks MathJAX.
This bug causes the page crashing and the status flashing under some circumstances. So I marked this as important.

### Instructions

```
sudo su - mastodon
RAILS_ENV=production bundle exec rails assets:precompile
exit
sudo su
systemctl reload mastodon-web
```