### PR TITLE
Change federation relay policy

### DIFF
--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -100,7 +100,7 @@ class RemoveStatusService < BaseService
   end
 
   def relayable?
-    @status.public_visibility?
+    false
   end
 
   def relay!

--- a/app/workers/activitypub/distribute_poll_update_worker.rb
+++ b/app/workers/activitypub/distribute_poll_update_worker.rb
@@ -24,7 +24,7 @@ class ActivityPub::DistributePollUpdateWorker
   private
 
   def relayable?
-    @status.public_visibility?
+    false
   end
 
   def inboxes

--- a/app/workers/activitypub/distribution_worker.rb
+++ b/app/workers/activitypub/distribution_worker.rb
@@ -28,7 +28,7 @@ class ActivityPub::DistributionWorker
   end
 
   def relayable?
-    @status.public_visibility?
+    false
   end
 
   def inboxes


### PR DESCRIPTION
Federation relays significantly increase the number of toots available on federated timeline. They work as ActivityPub actors which forward everything received from their inboxes to all instances who subscribe to the relays.

Some common federation relays:
- https://mastodon-relay.moew.science/inbox (Recommended for Chinese users)
- https://relay.toot.yukimochi.jp/inbox (Warning: huge number of Japanese toots)

However, due to the content on our server, it may not be acceptable to relay our public toots.
This PR allows our server to add federation relay without pushing our public statuses outside through the relay.

You will need to restart sidekiq as well.